### PR TITLE
output rules as jsonl, gently normalize columns

### DIFF
--- a/checkov_check.py
+++ b/checkov_check.py
@@ -1,8 +1,15 @@
+from pathlib import Path
+import json
 from collections import Counter
 
 from checkov import main as side_effect
 from checkov.common.util.docs_generator import get_checks
 
+NORMALIZED_PROVIDER_NAMES = {
+    'aws': 'aws',
+    'azurerm': 'azure',
+    'google': 'gcp',
+}
 
 def main():
 
@@ -22,10 +29,12 @@ def main():
 
         if provider not in ("aws", "azurerm", "google"):
             continue
+        rule["provider"] = NORMALIZED_PROVIDER_NAMES[provider]
         rules.append(rule)
         rule_ids.add(rule["id"])
         stats[provider] += 1
 
+    Path('checkov_rules.jsonl').write_text('\n'.join(json.dumps(rule) for rule in rules))
     print(stats)
 
 

--- a/kics_check.py
+++ b/kics_check.py
@@ -26,6 +26,8 @@ def main(path="kics"):
                     name=check["queryName"],
                 )
             )
+
+    Path('kics_rules.jsonl').write_text('\n'.join(json.dumps(rule) for rule in rules))
     print(stats)
 
 

--- a/kics_check.py
+++ b/kics_check.py
@@ -21,7 +21,7 @@ def main(path="kics"):
                 dict(
                     id=check["id"],
                     provider=check["cloudProvider"],
-                    severity=check["severity"].lower(),
+                    severity=check["severity"].title(),
                     description=check["descriptionText"],
                     name=check["queryName"],
                 )

--- a/terrascan_check.py
+++ b/terrascan_check.py
@@ -20,6 +20,7 @@ def main(path="terrascan"):
         for cpath in checks:
             c = json.loads(cpath.read_text())
             c["provider"] = c.pop("policy_type")
+            c["severity"] = c["severity"].title()
             rules.append(
                 {
                     k: v

--- a/terrascan_check.py
+++ b/terrascan_check.py
@@ -19,15 +19,17 @@ def main(path="terrascan"):
         stats[provider + "_unique"] += len(defines)
         for cpath in checks:
             c = json.loads(cpath.read_text())
+            c["provider"] = c.pop("policy_type")
             rules.append(
                 {
                     k: v
                     for k, v in c.items()
-                    if k in ("policy_type", "severity", "description", "id", "category")
+                    if k in ("provider", "severity", "description", "id", "category")
                 }
             )
     print(stats)
 
+    Path('terrascan_rules.jsonl').write_text('\n'.join(json.dumps(rule) for rule in rules))
 
 #    print(len(rules))
 

--- a/trivy_check.py
+++ b/trivy_check.py
@@ -82,6 +82,7 @@ def extract_rule(lines):
     rule["description"] = rule.pop("explanation")
     rule["id"] = rule.pop("avdid")
     rule["provider"] = NORMALIZED_PROVIDER_NAMES[rule["provider"]]
+    rule["severity"] = rule["severity"].split(".")[1]
     return rule
 
 

--- a/trivy_check.py
+++ b/trivy_check.py
@@ -1,10 +1,17 @@
+import json
 from collections import Counter
 from pathlib import Path
 import pprint
 
 
+NORMALIZED_PROVIDER_NAMES = {
+    'providers.AWSProvider': 'aws',
+    'providers.AzureProvider': 'azure',
+    'providers.GoogleProvider': 'gcp',
+}
+
 def main(path="defsec"):
-    rules_dir = Path(path) / "internal" / "rules"
+    rules_dir = Path(path) / "rules" / "cloud" / "policies"
 
     rules = []
     stats = Counter()
@@ -24,8 +31,8 @@ def main(path="defsec"):
                 stats[provider] += 1
                 rules.append(rule)
 
+    Path('trivy_rules.jsonl').write_text('\n'.join(json.dumps(rule) for rule in rules))
     print(stats)
-
 
 #    print(len(rules))
 
@@ -69,8 +76,12 @@ def extract_rule(lines):
         for k in rule_keys:
             if l.strip().startswith(k):
                 v = l.split(":", 1)[-1]
-                v = v.strip().strip('"').strip(",")
+                v = v.strip().strip('",`')
                 rule[k.lower()] = v
+    rule["name"] = rule.pop("summary")
+    rule["description"] = rule.pop("explanation")
+    rule["id"] = rule.pop("avdid")
+    rule["provider"] = NORMALIZED_PROVIDER_NAMES[rule["provider"]]
     return rule
 
 


### PR DESCRIPTION
- Use a common set of provider names
- Make sure each rule defines at least these columns:
  - id
  - provider
  - name and/or description
- Dump each tool's normalized rule set in JSONL format